### PR TITLE
Internalize things that shouldn't be public

### DIFF
--- a/Sources/FDB/Future/Future+Bytes.swift
+++ b/Sources/FDB/Future/Future+Bytes.swift
@@ -1,10 +1,10 @@
 import CFDB
 
 fileprivate class BytesContext {
-    typealias Closure = Future<Bytes?>.ReadyBytesClosure
+    internal typealias Closure = Future<Bytes?>.ReadyBytesClosure
 
-    let callback: Closure
-    let ctx: Future<Bytes?>
+    internal let callback: Closure
+    internal let ctx: Future<Bytes?>
     
     init(
         _ callback: @escaping Closure,
@@ -15,10 +15,10 @@ fileprivate class BytesContext {
     }
 }
 
-public extension Future where R == Bytes? {
-    public typealias ReadyBytesClosure = (_ bytes: Bytes?) throws -> Void
+internal extension Future where R == Bytes? {
+    internal typealias ReadyBytesClosure = (_ bytes: Bytes?) throws -> Void
 
-    public func whenReady(_ callback: @escaping ReadyBytesClosure) throws {
+    internal func whenReady(_ callback: @escaping ReadyBytesClosure) throws {
         try fdb_future_set_callback(
             self.pointer,
             { futurePtr, contextPtr in
@@ -33,7 +33,7 @@ public extension Future where R == Bytes? {
         ).orThrow()
     }
 
-    public func wait() throws -> Bytes? {
+    internal func wait() throws -> Bytes? {
         return try self.waitAndCheck().parseBytes(self.pointer)
     }
 

--- a/Sources/FDB/Future/Future+KeyValue.swift
+++ b/Sources/FDB/Future/Future+KeyValue.swift
@@ -1,12 +1,12 @@
 import CFDB
 
 fileprivate class KeyValueArrayContext {
-    typealias Closure = Future<KeyValuesResult>.ReadyKeyValuesClosure
+    internal typealias Closure = Future<KeyValuesResult>.ReadyKeyValuesClosure
 
-    let callback: Closure
-    let ctx: Future<KeyValuesResult>
+    internal let callback: Closure
+    internal let ctx: Future<KeyValuesResult>
     
-    init(
+    internal init(
         _ callback: @escaping Closure,
         _ ctx: Future<KeyValuesResult>
     ) {
@@ -15,10 +15,10 @@ fileprivate class KeyValueArrayContext {
     }
 }
 
-public extension Future where R == KeyValuesResult {
-    public typealias ReadyKeyValuesClosure = (_ result: KeyValuesResult) throws -> Void
+internal extension Future where R == KeyValuesResult {
+    internal typealias ReadyKeyValuesClosure = (_ result: KeyValuesResult) throws -> Void
 
-    public func whenReady(_ callback: @escaping ReadyKeyValuesClosure) throws {
+    internal func whenReady(_ callback: @escaping ReadyKeyValuesClosure) throws {
         try fdb_future_set_callback(
             self.pointer,
             { futurePtr, contextPtr in
@@ -34,7 +34,7 @@ public extension Future where R == KeyValuesResult {
         ).orThrow()
     }
 
-    public func wait() throws -> KeyValuesResult {
+    internal func wait() throws -> KeyValuesResult {
         return try self.waitAndCheck().parseKeyValues(self.pointer)
     }
 

--- a/Sources/FDB/Future/Future+OpaquePointer.swift
+++ b/Sources/FDB/Future/Future+OpaquePointer.swift
@@ -1,9 +1,9 @@
 internal extension OpaquePointer {
-    func asFuture<R>() -> Future<R> {
+    internal func asFuture<R>() -> Future<R> {
         return Future<R>(self)
     }
 
-    @discardableResult func waitForFuture<R>() throws -> Future<R> {
+    @discardableResult internal func waitForFuture<R>() throws -> Future<R> {
         return try self.asFuture().waitAndCheck()
     }
 }

--- a/Sources/FDB/Future/Future+Void.swift
+++ b/Sources/FDB/Future/Future+Void.swift
@@ -1,12 +1,12 @@
 import CFDB
 
 fileprivate class VoidContext {
-    typealias Closure = Future<Void>.ReadyVoidClosure
+    internal typealias Closure = Future<Void>.ReadyVoidClosure
 
-    let callback: Closure
-    let ctx: Future<Void>
+    internal let callback: Closure
+    internal let ctx: Future<Void>
     
-    init(
+    internal init(
         _ callback: @escaping Closure,
         _ ctx: Future<Void>
     ) {
@@ -15,10 +15,10 @@ fileprivate class VoidContext {
     }
 }
 
-public extension Future where R == Void {
-    public typealias ReadyVoidClosure = (_ future: Future<Void>) throws -> Void
+internal extension Future where R == Void {
+    internal typealias ReadyVoidClosure = (_ future: Future<Void>) throws -> Void
 
-    public func whenReady(_ callback: @escaping ReadyVoidClosure) throws {
+    internal func whenReady(_ callback: @escaping ReadyVoidClosure) throws {
         try fdb_future_set_callback(
             self.pointer,
             { _, contextPtr in

--- a/Sources/FDB/Future/Future.swift
+++ b/Sources/FDB/Future/Future.swift
@@ -1,11 +1,11 @@
 import CFDB
 
-public class Future<R> {
-    public let pointer: OpaquePointer
+internal class Future<R> {
+    internal let pointer: OpaquePointer
 
     private var failClosure: ((Error) -> Void)? = nil
 
-    public init(_ pointer: OpaquePointer) {
+    internal init(_ pointer: OpaquePointer) {
         self.pointer = pointer
     }
 
@@ -14,17 +14,17 @@ public class Future<R> {
         fdb_future_destroy(self.pointer)
     }
 
-    @discardableResult public func wait() throws -> Future {
+    @discardableResult internal func wait() throws -> Future {
         try fdb_future_block_until_ready(self.pointer).orThrow()
         return self
     }
 
-    public func checkError() throws -> Future {
+    internal func checkError() throws -> Future {
         try fdb_future_get_error(self.pointer).orThrow()
         return self
     }
 
-    @discardableResult public func waitAndCheck() throws -> Future {
+    @discardableResult internal func waitAndCheck() throws -> Future {
         return try self.wait().checkError()
     }
 
@@ -38,7 +38,7 @@ public class Future<R> {
         self.failClosure?(error)
     }
 
-    public func whenError(_ closure: @escaping (Error) -> Void) {
+    internal func whenError(_ closure: @escaping (Error) -> Void) {
         self.failClosure = closure
     }
 }

--- a/Sources/FDB/Tuple/Tuple+Int.swift
+++ b/Sources/FDB/Tuple/Tuple+Int.swift
@@ -1,12 +1,12 @@
 extension Collection where Index: Comparable {
-    @inlinable internal subscript(from i: Int) -> SubSequence {
+    internal subscript(from i: Int) -> SubSequence {
         let _from = self.index(self.endIndex, offsetBy: i)
         let _to = self.endIndex
         return self[_from..<_to]
     }
 }
 
-@inlinable internal func bisect(list: [Int], item: Int) -> Int {
+internal func bisect(list: [Int], item: Int) -> Int {
     var count = 0
     for i in list {
         if i >= item {

--- a/Sources/FDB/Tuple/Tuple+Unpack.swift
+++ b/Sources/FDB/Tuple/Tuple+Unpack.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-@inlinable internal func findTerminator(input: Bytes, pos: Int) -> Int {
+internal func findTerminator(input: Bytes, pos: Int) -> Int {
     let length = input.count
     var _pos = pos
     while true {
@@ -16,7 +16,7 @@ import Foundation
 }
 
 extension ArraySlice where Element == Byte {
-    @inlinable internal func replaceEscapes() -> Bytes {
+    internal func replaceEscapes() -> Bytes {
         if self.count == 0 {
             return []
         }

--- a/Sources/FDB/Tuple/Tuple.swift
+++ b/Sources/FDB/Tuple/Tuple.swift
@@ -9,15 +9,15 @@ public extension TuplePackable {
     }
 }
 
-let NULL: Byte                 = 0x00
-let PREFIX_BYTE_STRING: Byte   = 0x01
-let PREFIX_UTF_STRING: Byte    = 0x02
-let PREFIX_NESTED_TUPLE: Byte  = 0x05
-let PREFIX_INT_ZERO_CODE: Byte = 0x14
-let PREFIX_POS_INT_END: Byte   = 0x1d
-let PREFIX_NEG_INT_START: Byte = 0x0b
+internal let NULL: Byte                 = 0x00
+internal let PREFIX_BYTE_STRING: Byte   = 0x01
+internal let PREFIX_UTF_STRING: Byte    = 0x02
+internal let PREFIX_NESTED_TUPLE: Byte  = 0x05
+internal let PREFIX_INT_ZERO_CODE: Byte = 0x14
+internal let PREFIX_POS_INT_END: Byte   = 0x1d
+internal let PREFIX_NEG_INT_START: Byte = 0x0b
 
-let NULL_ESCAPE_SEQUENCE: Bytes = [NULL, 0xFF]
+internal let NULL_ESCAPE_SEQUENCE: Bytes = [NULL, 0xFF]
 
 public struct Null: TuplePackable {
     public func pack() -> Bytes {


### PR DESCRIPTION
Originally `Future` class was intended to be `public`, but since this project adopted Swift-NIO, local `Future` class became just a proxy between FoundationDB and NIO's `EventLoopFuture`s, and therefore should be `internal` now.

Major version bump is not needed, because module users couldn't interact with it anyway even though it was public.