### PR TITLE
Incorrect null escaped byte strings unpacked fix, etc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ install:
     fi
 before_script:
   - sudo apt-get install -y wget
-  - wget https://www.foundationdb.org/downloads/5.2.5/ubuntu/installers/foundationdb-clients_5.2.5-1_amd64.deb
-  - wget https://www.foundationdb.org/downloads/5.2.5/ubuntu/installers/foundationdb-server_5.2.5-1_amd64.deb
-  - sudo dpkg -i foundationdb-clients_5.2.5-1_amd64.deb foundationdb-server_5.2.5-1_amd64.deb
+  - wget https://www.foundationdb.org/downloads/6.0.15/ubuntu/installers/foundationdb-clients_6.0.15-1_amd64.deb
+  - wget https://www.foundationdb.org/downloads/6.0.15/ubuntu/installers/foundationdb-server_6.0.15-1_amd64.deb
+  - sudo dpkg -i foundationdb-clients_6.0.15-1_amd64.deb foundationdb-server_6.0.15-1_amd64.deb
   - sudo service foundationdb start
   - chmod +x scripts/install_pkgconfig.sh
   - sudo ./scripts/install_pkgconfig.sh

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "FDB", targets: ["FDB"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/kirilltitov/CFDBSwift", from: "1.0.0"),
+        .package(url: "https://github.com/kirilltitov/CFDBSwift", from: "1.0.3"),
         .package(url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "1.9.0")),
     ],
     targets: [

--- a/Sources/FDB/Tuple/Tuple+Unpack.swift
+++ b/Sources/FDB/Tuple/Tuple+Unpack.swift
@@ -23,18 +23,16 @@ extension ArraySlice where Element == Byte {
         var result = Bytes()
         var pos = self.startIndex
         let lastIndex = self.endIndex - 1
-        var i = 0
         while true {
-            i += 1
+            if pos > lastIndex {
+                break
+            }
             if self[pos] == 0x00 && pos < lastIndex && self[pos + 1] == 0xFF {
                 result.append(0x00)
                 pos += 2
                 continue
             }
             result.append(self[pos])
-            if pos == lastIndex {
-                break
-            }
             pos += 1
         }
         return result

--- a/Sources/FDB/Tuple/Tuple.swift
+++ b/Sources/FDB/Tuple/Tuple.swift
@@ -1,3 +1,24 @@
+// You may adopt this protocol with any of your custom types.
+// You should only implement pack() method, not _pack().
+// Obviously, in most cases you would like to treat your
+// class/struct as binary string, this is why simply returning
+// bytes of your internal value representation is incorrect,
+// because noone would know that your returned byte array
+// should actually be treated as a binary string.
+// It must be wrapped with control characters first.
+// This is why you should additionally call .pack() from your
+// resulting byte array (see Tuple+Array.swift). Otherwise packing
+// will be incorrect, but most importantly - unpacking will
+// fail with a fatal error.
+// Example of custom pack() implementation:
+// extension MyValue {
+//     public func pack() -> Bytes {
+//         self
+//             .getBytesSomehow() // your method returns [UInt8]
+//             .pack()            // this will wrap your bytes
+//                                // with tuple binary string magic :)
+//     }
+// }
 public protocol TuplePackable {
     func pack() -> Bytes
     func _pack() -> Bytes
@@ -60,5 +81,16 @@ public struct Tuple: TuplePackable {
         }
         result.append(NULL)
         return result
+    }
+}
+
+// I DON'T LIKE IT SO MUCH
+extension Tuple: Hashable {
+    public static func == (lhs: Tuple, rhs: Tuple) -> Bool {
+        return lhs.pack() == rhs.pack()
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.pack())
     }
 }

--- a/Tests/FDBTests/TupleTests.swift
+++ b/Tests/FDBTests/TupleTests.swift
@@ -122,15 +122,16 @@ class TupleTests: XCTestCase {
             Tuple(),
             nil,
         ]
-        #if os(Linux)
-            // linux currently null-terminates strings :(
-            // https://bugs.swift.org/browse/SR-7455
-            input.append("foobar")
-        #else
-            input.append("foo\u{00}bar")
-        #endif
+        input.append("foo\u{00}bar")
         let etalonTuple = Tuple(input)
         let packed = etalonTuple.pack()
+        let repacked = Tuple(from: packed).pack()
+        XCTAssertEqual(packed, repacked)
+    }
+
+    // Fixes https://github.com/kirilltitov/FDBSwift/issues/10
+    func testNullEscapes() {
+        let packed = Bytes([0, 0, 0,]).pack()
         let repacked = Tuple(from: packed).pack()
         XCTAssertEqual(packed, repacked)
     }

--- a/Tests/FDBTests/TupleTests.swift
+++ b/Tests/FDBTests/TupleTests.swift
@@ -122,7 +122,11 @@ class TupleTests: XCTestCase {
             Tuple(),
             nil,
         ]
-        input.append("foo\u{00}bar")
+        #if os(Linux)
+            input.append("foobar")
+        #else
+            input.append("foo\u{00}bar")
+        #endif
         let etalonTuple = Tuple(input)
         let packed = etalonTuple.pack()
         let repacked = Tuple(from: packed).pack()


### PR DESCRIPTION
Fixes #10
* Updated TuplePackable doc
* Bumped FoundationDB version to 6.0.15 in .travis.yml