### PR TITLE
Rename FDBKey to AnyFDBKey

### DIFF
--- a/Sources/FDB/AnyFDBKey.swift
+++ b/Sources/FDB/AnyFDBKey.swift
@@ -1,31 +1,30 @@
 public extension FDB {
-    public typealias RangeKey = (begin: FDBKey, end: FDBKey)
+    public typealias RangeKey = (begin: AnyFDBKey, end: AnyFDBKey)
 }
 
-// todo rename to AnyFDBKey
-public protocol FDBKey: FDBTuplePackable {
+public protocol AnyFDBKey: FDBTuplePackable {
     func asFDBKey() -> Bytes
 }
 
-public extension FDBKey {
+public extension AnyFDBKey {
     public func pack() -> Bytes {
         return self.asFDBKey().pack()
     }
 }
 
-extension String: FDBKey {
+extension String: AnyFDBKey {
     public func asFDBKey() -> Bytes {
         return Bytes(self.utf8)
     }
 }
 
-extension StaticString: FDBKey {
+extension StaticString: AnyFDBKey {
     public func asFDBKey() -> Bytes {
         return self.utf8Start.getBytes(count: Int32(self.utf8CodeUnitCount))
     }
 }
 
-extension Array: FDBKey where Element == Byte {
+extension Array: AnyFDBKey where Element == Byte {
     public func asFDBKey() -> Bytes {
         return self
     }

--- a/Sources/FDB/Deprecated.swift
+++ b/Sources/FDB/Deprecated.swift
@@ -1,0 +1,2 @@
+@available(*, unavailable, renamed: "AnyFDBKey")
+public typealias FDBKey = AnyFDBKey

--- a/Sources/FDB/FDB.swift
+++ b/Sources/FDB/FDB.swift
@@ -222,15 +222,15 @@ public class FDB {
         self.debug("Connected")
     }
 
-    public func set(key: FDBKey, value: Bytes) throws {
+    public func set(key: AnyFDBKey, value: Bytes) throws {
         try self.begin().set(key: key, value: value, commit: true) as Void
     }
 
-    public func clear(key: FDBKey) throws {
+    public func clear(key: AnyFDBKey) throws {
         return try self.begin().clear(key: key, commit: true)
     }
 
-    public func clear(begin: FDBKey, end: FDBKey) throws {
+    public func clear(begin: AnyFDBKey, end: AnyFDBKey) throws {
         return try self.begin().clear(begin: begin, end: end, commit: true)
     }
 
@@ -242,7 +242,7 @@ public class FDB {
         return try self.clear(range: subspace.range)
     }
 
-    public func get(key: FDBKey, snapshot: Int32 = 0) throws -> Bytes? {
+    public func get(key: AnyFDBKey, snapshot: Int32 = 0) throws -> Bytes? {
         return try self.begin().get(key: key, snapshot: snapshot, commit: true)
     }
 
@@ -251,8 +251,8 @@ public class FDB {
     }
 
     public func get(
-        begin: FDBKey,
-        end: FDBKey,
+        begin: AnyFDBKey,
+        end: AnyFDBKey,
         beginEqual: Bool = false,
         beginOffset: Int32 = 1,
         endEqual: Bool = false,
@@ -310,15 +310,15 @@ public class FDB {
         )
     }
 
-    public func atomic(_ op: FDB.MutationType, key: FDBKey, value: Bytes) throws {
+    public func atomic(_ op: FDB.MutationType, key: AnyFDBKey, value: Bytes) throws {
         try self.begin().atomic(op, key: key, value: value, commit: true) as Void
     }
 
-    public func atomic<T: SignedInteger>(_ op: FDB.MutationType, key: FDBKey, value: T) throws {
+    public func atomic<T: SignedInteger>(_ op: FDB.MutationType, key: AnyFDBKey, value: T) throws {
         try self.atomic(op, key: key, value: getBytes(value))
     }
 
-    @discardableResult public func increment(key: FDBKey, value: Int64 = 1) throws -> Int64 {
+    @discardableResult public func increment(key: AnyFDBKey, value: Int64 = 1) throws -> Int64 {
         let transaction = try self.begin()
         try transaction.atomic(.add, key: key, value: getBytes(value), commit: false) as Void
         guard let bytes: Bytes = try transaction.get(key: key) else {
@@ -328,7 +328,7 @@ public class FDB {
         return bytes.cast()
     }
 
-    @discardableResult public func decrement(key: FDBKey, value: Int64 = 1) throws -> Int64 {
+    @discardableResult public func decrement(key: AnyFDBKey, value: Int64 = 1) throws -> Int64 {
         return try self.increment(key: key, value: -value)
     }
 }

--- a/Sources/FDB/Subspace.swift
+++ b/Sources/FDB/Subspace.swift
@@ -37,7 +37,7 @@ public extension FDB {
     }
 }
 
-extension FDB.Subspace: FDBKey {
+extension FDB.Subspace: AnyFDBKey {
     public func asFDBKey() -> Bytes {
         return self.prefix
     }

--- a/Sources/FDB/Transaction/Transaction+Base.swift
+++ b/Sources/FDB/Transaction/Transaction+Base.swift
@@ -29,12 +29,12 @@ public extension FDB {
             fdb_transaction_reset(self.DBPointer)
         }
         
-        public func clear(key: FDBKey) {
+        public func clear(key: AnyFDBKey) {
             let keyBytes = key.asFDBKey()
             fdb_transaction_clear(self.DBPointer, keyBytes, keyBytes.length)
         }
         
-        public func clear(begin: FDBKey, end: FDBKey) {
+        public func clear(begin: AnyFDBKey, end: AnyFDBKey) {
             let beginBytes = begin.asFDBKey()
             let endBytes = end.asFDBKey()
             fdb_transaction_clear_range(self.DBPointer, beginBytes, beginBytes.length, endBytes, endBytes.length)
@@ -44,7 +44,7 @@ public extension FDB {
             self.clear(begin: range.begin, end: range.end)
         }
         
-        public func atomic(_ op: FDB.MutationType, key: FDBKey, value: Bytes) {
+        public func atomic(_ op: FDB.MutationType, key: AnyFDBKey, value: Bytes) {
             let keyBytes = key.asFDBKey()
             fdb_transaction_atomic_op(
                 self.DBPointer,

--- a/Sources/FDB/Transaction/Transaction+Internal+Async.swift
+++ b/Sources/FDB/Transaction/Transaction+Internal+Async.swift
@@ -5,19 +5,19 @@ internal extension FDB.Transaction {
         return fdb_transaction_commit(self.DBPointer).asFuture()
     }
 
-    internal func set(key: FDBKey, value: Bytes) {
+    internal func set(key: AnyFDBKey, value: Bytes) {
         let keyBytes = key.asFDBKey()
         fdb_transaction_set(self.DBPointer, keyBytes, keyBytes.length, value, value.length)
     }
 
-    internal func get(key: FDBKey, snapshot: Int32 = 0) -> Future<Bytes?> {
+    internal func get(key: AnyFDBKey, snapshot: Int32 = 0) -> Future<Bytes?> {
         let keyBytes = key.asFDBKey()
         return fdb_transaction_get(self.DBPointer, keyBytes, keyBytes.length, snapshot).asFuture()
     }
 
     internal func get(
-        begin: FDBKey,
-        end: FDBKey,
+        begin: AnyFDBKey,
+        end: AnyFDBKey,
         beginEqual: Bool = false,
         beginOffset: Int32 = 1,
         endEqual: Bool = false,

--- a/Sources/FDB/Transaction/Transaction+NIO.swift
+++ b/Sources/FDB/Transaction/Transaction+NIO.swift
@@ -34,7 +34,7 @@ public extension FDB.Transaction {
         }
     }
 
-    public func set(key: FDBKey, value: Bytes, commit: Bool = false) -> EventLoopFuture<FDB.Transaction> {
+    public func set(key: AnyFDBKey, value: Bytes, commit: Bool = false) -> EventLoopFuture<FDB.Transaction> {
         guard let eventLoop = self.eventLoop else {
             return FDB.dummyEventLoop.newFailedFuture(error: FDB.Error.noEventLoopProvided)
         }
@@ -49,7 +49,7 @@ public extension FDB.Transaction {
     }
 
     public func get(
-        key: FDBKey,
+        key: AnyFDBKey,
         snapshot: Int32 = 0,
         commit: Bool = false
     ) -> EventLoopFuture<(Bytes?, FDB.Transaction)> {
@@ -77,8 +77,8 @@ public extension FDB.Transaction {
     }
 
     public func get(
-        begin: FDBKey,
-        end: FDBKey,
+        begin: AnyFDBKey,
+        end: AnyFDBKey,
         beginEqual: Bool = false,
         beginOffset: Int32 = 1,
         endEqual: Bool = false,
@@ -171,13 +171,13 @@ public extension FDB.Transaction {
         return future
     }
 
-    public func clear(key: FDBKey, commit: Bool = false) -> EventLoopFuture<FDB.Transaction> {
+    public func clear(key: AnyFDBKey, commit: Bool = false) -> EventLoopFuture<FDB.Transaction> {
         return self.genericAction(commit: commit) {
             self.clear(key: key)
         }
     }
 
-    public func clear(begin: FDBKey, end: FDBKey, commit: Bool = false) -> EventLoopFuture<FDB.Transaction> {
+    public func clear(begin: AnyFDBKey, end: AnyFDBKey, commit: Bool = false) -> EventLoopFuture<FDB.Transaction> {
         return self.genericAction(commit: commit) {
             self.clear(begin: begin, end: end)
         }
@@ -191,7 +191,7 @@ public extension FDB.Transaction {
 
     public func atomic(
         _ op: FDB.MutationType,
-        key: FDBKey,
+        key: AnyFDBKey,
         value: Bytes,
         commit: Bool = false
     ) -> EventLoopFuture<FDB.Transaction> {
@@ -202,7 +202,7 @@ public extension FDB.Transaction {
 
     public func atomic<T>(
         _ op: FDB.MutationType,
-        key: FDBKey,
+        key: AnyFDBKey,
         value: T,
         commit: Bool = false
     ) -> EventLoopFuture<FDB.Transaction> {

--- a/Sources/FDB/Transaction/Transaction+Sync.swift
+++ b/Sources/FDB/Transaction/Transaction+Sync.swift
@@ -11,14 +11,14 @@ public extension FDB.Transaction {
         }
     }
 
-    public func set(key: FDBKey, value: Bytes, commit: Bool = false) throws {
+    public func set(key: AnyFDBKey, value: Bytes, commit: Bool = false) throws {
         self.set(key: key, value: value)
         if commit {
             try self.commitSync()
         }
     }
 
-    public func get(key: FDBKey, snapshot: Int32 = 0, commit: Bool = false) throws -> Bytes? {
+    public func get(key: AnyFDBKey, snapshot: Int32 = 0, commit: Bool = false) throws -> Bytes? {
         let result = try self.get(key: key, snapshot: snapshot).wait()
         if commit {
             try self.commitSync()
@@ -27,8 +27,8 @@ public extension FDB.Transaction {
     }
 
     public func get(
-        begin: FDBKey,
-        end: FDBKey,
+        begin: AnyFDBKey,
+        end: AnyFDBKey,
         beginEqual: Bool = false,
         beginOffset: Int32 = 1,
         endEqual: Bool = false,
@@ -95,14 +95,14 @@ public extension FDB.Transaction {
         return try future.wait()
     }
 
-    public func clear(key: FDBKey, commit: Bool = false) throws {
+    public func clear(key: AnyFDBKey, commit: Bool = false) throws {
         self.clear(key: key)
         if commit {
             try self.commitSync()
         }
     }
 
-    public func clear(begin: FDBKey, end: FDBKey, commit: Bool = false) throws {
+    public func clear(begin: AnyFDBKey, end: AnyFDBKey, commit: Bool = false) throws {
         self.clear(begin: begin, end: end)
         if commit {
             try self.commitSync()
@@ -113,14 +113,14 @@ public extension FDB.Transaction {
         try self.clear(begin: range.begin, end: range.end, commit: commit) as Void
     }
 
-    public func atomic(_ op: FDB.MutationType, key: FDBKey, value: Bytes, commit: Bool = false) throws {
+    public func atomic(_ op: FDB.MutationType, key: AnyFDBKey, value: Bytes, commit: Bool = false) throws {
         self.atomic(op, key: key, value: value)
         if commit {
             try self.commitSync()
         }
     }
 
-    public func atomic<T>(_ op: FDB.MutationType, key: FDBKey, value: T, commit: Bool = false) throws {
+    public func atomic<T>(_ op: FDB.MutationType, key: AnyFDBKey, value: T, commit: Bool = false) throws {
         self.atomic(op, key: key, value: getBytes(value))
         if commit {
             try self.commitSync()

--- a/Sources/FDB/Tuple/Tuple+Base.swift
+++ b/Sources/FDB/Tuple/Tuple+Base.swift
@@ -82,7 +82,7 @@ public extension FDB {
     }
 }
 
-extension FDB.Tuple: FDBKey {
+extension FDB.Tuple: AnyFDBKey {
     public func asFDBKey() -> Bytes {
         return self.pack()
     }


### PR DESCRIPTION
This is really just a type-erased thingy, and should be called appropriately. Plus add shim.