### PR TITLE
Make tuple unpack safe

### DIFF
--- a/Sources/FDB/FDB+Errors.swift
+++ b/Sources/FDB/FDB+Errors.swift
@@ -87,6 +87,11 @@ public extension FDB {
         case unexpectedError = 9000
         case noEventLoopProvided = 9500
         case connectionError = 9600
+        case unpackEmptyInput = 9701
+        case unpackTooLargeInt = 9702
+        case unpackUnknownCode = 9703
+        case unpackInvalidBoundaries = 9704
+        case unpackInvalidString = 9705
 
         public static func from(errno: FDB.Errno) -> Error {
             guard let error = FDB.Error(rawValue: errno) else {

--- a/Sources/FDB/FDB.swift
+++ b/Sources/FDB/FDB.swift
@@ -42,7 +42,7 @@ public class FDB {
 
     private var isConnected = false
 
-    public var verbose = false
+    public static var verbose = false
 
     private let semaphore = DispatchSemaphore(value: 0)
 
@@ -183,11 +183,15 @@ public class FDB {
         self.isConnected = true
         return try self.getDB()
     }
+    
+    internal static func debug(_ message: String) {
+        if self.verbose {
+            print(message)
+        }
+    }
 
     internal func debug(_ message: String) {
-        if self.verbose {
-            print("[FDB \(ObjectIdentifier(self))] \(message)")
-        }
+        FDB.debug("[FDB \(ObjectIdentifier(self))] \(message)")
     }
 
     public func begin() throws -> FDB.Transaction {

--- a/Sources/FDB/Tuple/Tuple+Unpack.swift
+++ b/Sources/FDB/Tuple/Tuple+Unpack.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-internal func findTerminator(input: Bytes, pos: Int) -> Int {
+fileprivate func findTerminator(input: Bytes, pos: Int) -> Int {
     let length = input.count
     var _pos = pos
     while true {
@@ -40,53 +40,79 @@ extension ArraySlice where Element == Byte {
 }
 
 extension FDB.Tuple {
-    public init(from bytes: Bytes) {
+    public init(from bytes: Bytes) throws {
         var result: [FDBTuplePackable] = []
         var pos = 0
         let length = bytes.count
         while pos < length {
             let slice = Bytes(bytes[pos...])
-            let res = FDB.Tuple._unpack(slice)
+            let res = try FDB.Tuple._unpack(slice)
             pos += res.1
             result.append(res.0)
         }
         self.init(result)
     }
     
-    internal static func _unpack(_ input: Bytes, _ pos: Int = 0) -> (FDBTuplePackable, Int) {
-        guard input.count > 0 else {
-            fatalError("Input is empty")
+    internal static func _unpack(_ input: Bytes, _ pos: Int = 0) throws -> (FDBTuplePackable, Int) {
+        func sanityCheck(begin: Int, end: Int) throws {
+            guard begin >= input.startIndex else {
+                FDB.debug("FDB: Invalid begin boundary \(begin) (actual: \(input.startIndex)) while parsing \(input)")
+                throw FDB.Error.unpackInvalidBoundaries
+            }
+            guard end <= input.endIndex else {
+                FDB.debug("FDB: Invalid end boundary \(end) (actual: \(input.endIndex)) while parsing \(input)")
+                throw FDB.Error.unpackInvalidBoundaries
+            }
         }
+
+        guard input.count > 0 else {
+            throw FDB.Error.unpackEmptyInput
+        }
+
         let code = input[pos]
         if code == NULL {
             return (FDB.Null(), pos + 1)
         } else if code == PREFIX_BYTE_STRING {
             let end = findTerminator(input: input, pos: pos + 1)
+            try sanityCheck(begin: pos + 1, end: end)
             return (input[(pos + 1) ..< end].replaceEscapes(), end + 1)
         } else if code == PREFIX_UTF_STRING {
             let _pos = pos + 1
             let end = findTerminator(input: input, pos: _pos)
+            try sanityCheck(begin: pos + 1, end: end)
             let bytes = input[(pos + 1) ..< end].replaceEscapes()
-            return (
-                String(bytes: bytes, encoding: .utf8)!,
-                end + 1
-            )
+            guard let string = String(bytes: bytes, encoding: .utf8) else {
+                FDB.debug("FDB: Could not convert bytes \(bytes) to string (ascii form: '\(String(bytes: bytes, encoding: .ascii)!)')")
+                throw FDB.Error.unpackInvalidString
+            }
+            return (string, end + 1)
         } else if code >= PREFIX_INT_ZERO_CODE && code < PREFIX_POS_INT_END {
             let n = Int(code) - 20
             let begin = pos + 1
             let end = begin + n
-            return ((Array<Byte>(repeating: 0x00, count: 8 - n) + input[begin ..< end]).reversed().cast() as Int, end)
+            try sanityCheck(begin: begin, end: end)
+            return (
+                (Array<Byte>(repeating: 0x00, count: 8 - n) + input[begin ..< end]).reversed().cast() as Int,
+                end
+            )
         } else if code > PREFIX_NEG_INT_START && code < PREFIX_INT_ZERO_CODE {
             let n = 20 - Int(code)
             let begin = pos + 1
             let end = pos + 1 + n
-            guard sizeLimits.count >= n else {
-                fatalError("Int too large to unpack")
+            guard n < sizeLimits.endIndex else {
+                throw FDB.Error.unpackTooLargeInt
             }
+            try sanityCheck(begin: begin, end: end)
             return (
                 (
-                    (Array<Byte>(repeating: 0x00, count: 8 - n) + input[begin ..< end]).reversed().cast() as Int
-                    ) - sizeLimits[n],
+                    (
+                        Array<Byte>(
+                            repeating: 0x00,
+                            count: 8 - n
+                        )
+                            + input[begin ..< end]
+                    ).reversed().cast() as Int
+                ) - sizeLimits[n],
                 end
             )
         } else if code == PREFIX_NESTED_TUPLE {
@@ -101,13 +127,15 @@ extension FDB.Tuple {
                         break
                     }
                 } else {
-                    let _res = FDB.Tuple._unpack(input, end)
+                    let _res = try FDB.Tuple._unpack(input, end)
                     result.append(_res.0)
                     end = _res.1
                 }
             }
             return (FDB.Tuple(result), end + 1)
         }
-        fatalError("Unknown code '\(code)'")
+
+        FDB.debug("FDB: Unknown tuple code '\(code)' while parsing \(input)")
+        throw FDB.Error.unpackUnknownCode
     }
 }

--- a/Tests/FDBTests/TupleTests.swift
+++ b/Tests/FDBTests/TupleTests.swift
@@ -111,7 +111,7 @@ class TupleTests: XCTestCase {
         XCTAssertEqual(FDB.Tuple(-1, 0, 5, FDB.Tuple("foo"), FDB.Null()).pack(), expected)
     }
 
-    func testUnpack() {
+    func testUnpack() throws {
         var input: [FDBTuplePackable] = [
             Bytes([0, 1, 2]),
             322,
@@ -129,15 +129,25 @@ class TupleTests: XCTestCase {
         #endif
         let etalonTuple = FDB.Tuple(input)
         let packed = etalonTuple.pack()
-        let repacked = FDB.Tuple(from: packed).pack()
+        let repacked = try FDB.Tuple(from: packed).pack()
         XCTAssertEqual(packed, repacked)
     }
 
     // Fixes https://github.com/kirilltitov/FDBSwift/issues/10
-    func testNullEscapes() {
+    func testNullEscapes() throws {
         let packed = Bytes([0, 0, 0,]).pack()
-        let repacked = FDB.Tuple(from: packed).pack()
+        let repacked = try FDB.Tuple(from: packed).pack()
         XCTAssertEqual(packed, repacked)
+    }
+    
+    func testUnpackSanity() {
+        for _ in 1...10000 {
+            do {
+                let _ = try FDB.Tuple(
+                    from: (1...UInt8.random(in: 10..<UInt8.max)).map { _ in UInt8.random(in: 0..<UInt8.max) }
+                )
+            } catch {}
+        }
     }
 
     static var allTests = [
@@ -148,5 +158,6 @@ class TupleTests: XCTestCase {
         ("testUnofficialCases", testUnofficialCases),
         ("testUnpack", testUnpack),
         ("testNullEscapes", testNullEscapes),
+        ("testUnpackSanity", testUnpackSanity),
     ]
 }


### PR DESCRIPTION
Two major points:
* unpack (`Tuple(from: myBytes)`) now may throw if invalid bytes are passed
* unpack became slower because of often sanity checks