### PR TITLE
Remove null-terminated string Linux shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ let tupleNull: FDBTuplePackable = unpacked.tuple[7]
 if tupleNull is FDB.Null || unpacked.tuple[7] is FDB.Null {}
 // you get the idea
 ```
-**Alert!** Due to a bug in Linux Swift Foundation (4.0+) any strings in Linux are decoded from `Bytes` or `Data` as null-terminated, i.e. `String(bytes: [102, 111, 111, 0, 98, 97, 114], encoding: .ascii)` on macOS would be `foo\u{00}bar` (as expected), but on Linux it's just `foo`. Keep that in mind, avoid using nulls in your string tuples.
 
 ### Setting values
 

--- a/Tests/FDBTests/TupleTests.swift
+++ b/Tests/FDBTests/TupleTests.swift
@@ -125,12 +125,8 @@ class TupleTests: XCTestCase {
             FDB.Tuple("bar", 1337, "baz"),
             FDB.Tuple(),
             FDB.Null(),
+            "foo\u{00}bar",
         ]
-        #if os(Linux)
-            input.append("foobar")
-        #else
-            input.append("foo\u{00}bar")
-        #endif
         let etalonTuple = FDB.Tuple(input)
         let packed = etalonTuple.pack()
         let repacked = try FDB.Tuple(from: packed).pack()

--- a/Tests/FDBTests/TupleTests.swift
+++ b/Tests/FDBTests/TupleTests.swift
@@ -116,7 +116,7 @@ class TupleTests: XCTestCase {
     }
 
     func testUnpack() throws {
-        var input: [FDBTuplePackable] = [
+        let input: [FDBTuplePackable] = [
             Bytes([0, 1, 2]),
             322,
             -322,


### PR DESCRIPTION
Now that we're in 5, this bug should've been fixed.