### PR TITLE
Implement release-safe version of precondition(condition:message:) func, rename Bytes.cast to Bytes.unsafeCast

### DIFF
--- a/Sources/FDB/FDB/FDB+Sync.swift
+++ b/Sources/FDB/FDB/FDB+Sync.swift
@@ -258,7 +258,7 @@ public extension FDB {
 
             try transaction.commitSync()
 
-            return bytes.cast()
+            return bytes.unsafeCast()
         }
     }
 

--- a/Sources/FDB/Helpers.swift
+++ b/Sources/FDB/Helpers.swift
@@ -5,6 +5,16 @@ import NIO
 public typealias Byte = UInt8
 public typealias Bytes = [Byte]
 
+internal func _precondition(
+    _ condition: @autoclosure () -> Bool,
+    _ message: @autoclosure () -> String = String(),
+    file: StaticString = #file, line: UInt = #line
+) {
+    guard condition() == true else {
+        fatalError("Precondition failed: \(message())", file: file, line: line)
+    }
+}
+
 internal extension FDB {
     struct OptionsHelper {
         @usableFromInline internal static func stringOptionToPointer(
@@ -52,8 +62,8 @@ internal extension Bool {
 }
 
 internal extension Array where Element == Byte {
-    @usableFromInline func cast<R>() -> R {
-        precondition(
+    @usableFromInline func unsafeCast<R>() -> R {
+        _precondition(
             MemoryLayout<R>.size == self.count,
             "Memory layout size for result type '\(R.self)' (\(MemoryLayout<R>.size) bytes) does not match with given byte array length (\(self.count) bytes)"
         )

--- a/Sources/FDB/Tuple/Tuple+Unpack.swift
+++ b/Sources/FDB/Tuple/Tuple+Unpack.swift
@@ -92,7 +92,7 @@ extension FDB.Tuple {
             let end = begin + n
             try sanityCheck(begin: begin, end: end)
             return (
-                (Array<Byte>(repeating: 0x00, count: 8 - n) + input[begin ..< end]).reversed().cast() as Int,
+                (Array<Byte>(repeating: 0x00, count: 8 - n) + input[begin ..< end]).reversed().unsafeCast() as Int,
                 end
             )
         } else if code > FDB.Tuple.Prefix.NEG_INT_START && code < FDB.Tuple.Prefix.INT_ZERO_CODE {
@@ -111,7 +111,7 @@ extension FDB.Tuple {
                             count: 8 - n
                         )
                             + input[begin ..< end]
-                    ).reversed().cast() as Int
+                    ).reversed().unsafeCast() as Int
                 ) - sizeLimits[n],
                 end
             )
@@ -139,7 +139,7 @@ extension FDB.Tuple {
             var bytes = Bytes(input[(pos + 1) ..< end])
             transformFloatingPoint(bytes: &bytes, start: 0, encode: false)
             return (
-                Float32(bitPattern: (bytes.cast() as UInt32).bigEndian),
+                Float32(bitPattern: (bytes.unsafeCast() as UInt32).bigEndian),
                 end
             )
         } else if code == FDB.Tuple.Prefix.DOUBLE {
@@ -148,7 +148,7 @@ extension FDB.Tuple {
             var bytes = Bytes(input[(pos + 1) ..< end])
             transformFloatingPoint(bytes: &bytes, start: 0, encode: false)
             return (
-                Double(bitPattern: (bytes.cast() as UInt64).bigEndian),
+                Double(bitPattern: (bytes.unsafeCast() as UInt64).bigEndian),
                 end
             )
         } else if code == FDB.Tuple.Prefix.BOOL_TRUE || code == FDB.Tuple.Prefix.BOOL_FALSE {
@@ -160,7 +160,7 @@ extension FDB.Tuple {
             let end = pos + 1 + MemoryLayout<uuid_t>.size
             try sanityCheck(begin: pos + 1, end: end)
             return (
-                UUID(uuid: Bytes(input[(pos + 1) ..< end]).cast()),
+                UUID(uuid: Bytes(input[(pos + 1) ..< end]).unsafeCast()),
                 end
             )
         }

--- a/Tests/FDBTests/FDBTests.swift
+++ b/Tests/FDBTests/FDBTests.swift
@@ -94,7 +94,7 @@ class FDBTests: XCTestCase {
         XCTAssertNoThrow(try fdb.increment(key: key))
         let result = try fdb.get(key: key)
         XCTAssertNotNil(result)
-        XCTAssertEqual(result!.cast() as Int64, expected)
+        XCTAssertEqual(result!.unsafeCast() as Int64, expected)
         XCTAssertEqual(result, getBytes(expected))
         XCTAssertEqual(try fdb.increment(key: key), expected + 1)
         XCTAssertEqual(try fdb.increment(key: key, value: -1), expected)
@@ -233,7 +233,7 @@ class FDBTests: XCTestCase {
         let _ = semaphore.wait(for: 10)
         let result: Bytes? = try tr.get(key: key).wait()
         XCTAssertNotNil(result)
-        XCTAssertEqual(result!.cast() as Int64, expected)
+        XCTAssertEqual(result!.unsafeCast() as Int64, expected)
         XCTAssertEqual(result, getBytes(expected))
 //      TODO:
 //      XCTAssertEqual(try fdb.increment(key: key), expected + 1)
@@ -306,7 +306,7 @@ class FDBTests: XCTestCase {
                     try transaction.commitSync()
                     return value
                 }
-                resultSync.append(resultValue!.cast())
+                resultSync.append(resultValue!.unsafeCast())
                 if resultSync.count == etalon.count {
                     semaphoreSync.signal()
                 }
@@ -319,7 +319,7 @@ class FDBTests: XCTestCase {
                             return transaction.get(key: keyAsync, commit: true)
                         }
                         .map { (bytes: Bytes?, transaction: FDB.Transaction) -> Void in
-                            let value: Int64 = bytes!.cast()
+                            let value: Int64 = bytes!.unsafeCast()
                             resultAsync.append(value)
                             if resultAsync.count == etalon.count {
                                 semaphoreAsync.signal()


### PR DESCRIPTION
Fixes #45.