### PR TITLE
Support for Versionstamps

### DIFF
--- a/Sources/FDB/AnyFDBTransaction.swift
+++ b/Sources/FDB/AnyFDBTransaction.swift
@@ -64,6 +64,19 @@ public protocol AnyFDBTransaction {
     /// - returns: EventLoopFuture with future Transaction (`self`) value
     func set(key: AnyFDBKey, value: Bytes, commit: Bool) -> EventLoopFuture<AnyFDBTransaction>
 
+    /// Sets bytes to given versionstamped key in FDB cluster. If versionstampedKey does not contain
+    /// an incomplete version stamp, this method will throw an error. The actual version stamp used
+    /// may be retrieved by calling `getVersionstamp()` on the transaction.
+    ///
+    /// - parameters:
+    ///   - versionstampedKey: FDB key containing an incomplete Versionstamp
+    ///   - value: Bytes value
+    ///   - commit: Whether to commit this transaction after action or not
+    ///
+    /// - Throws: Throws FDB.Error.missingIncompleteVersionstamp if a version stamp cannot be found
+    /// - returns: EventLoopFuture with future Transaction (`self`) value
+    func set(versionstampedKey: AnyFDBKey, value: Bytes, commit: Bool) throws -> EventLoopFuture<AnyFDBTransaction>
+
     /// Returns bytes value for given key (or `nil` if no key)
     ///
     /// - parameters:
@@ -295,6 +308,20 @@ public protocol AnyFDBTransaction {
     ///   - commit: Whether to commit this transaction after action or not
     func set(key: AnyFDBKey, value: Bytes, commit: Bool) throws
 
+    /// Sets bytes to given versionstamped key in FDB cluster. If versionstampedKey does not contain
+    /// an incomplete version stamp, this method will throw an error. The actual version stamp used
+    /// may be retrieved by calling `getVersionstamp()` on the transaction.
+    ///
+    /// This function will block current thread during execution
+    ///
+    /// - parameters:
+    ///   - versionstampedKey: FDB key containing an incomplete Versionstamp
+    ///   - value: Bytes value
+    ///   - commit: Whether to commit this transaction after action or not
+    ///
+    /// - Throws: Throws FDB.Error.missingIncompleteVersionstamp if a version stamp cannot be found
+    func set(versionstampedKey: AnyFDBKey, value: Bytes, commit: Bool) throws
+
     /// Returns bytes value for given key (or `nil` if no key)
     ///
     /// This function will block current thread during execution
@@ -447,6 +474,22 @@ public extension AnyFDBTransaction {
     ///   - commit: Whether to commit this transaction after action or not
     func set(key: AnyFDBKey, value: Bytes, commit: Bool = false) throws {
         try self.set(key: key, value: value, commit: commit) as Void
+    }
+
+    /// Sets bytes to given versionstamped key in FDB cluster. If versionstampedKey does not contain
+    /// an incomplete version stamp, this method will throw an error. The actual version stamp used
+    /// may be retrieved by calling `getVersionstamp()` on the transaction.
+    ///
+    /// This function will block current thread during execution
+    ///
+    /// - parameters:
+    ///   - versionstampedKey: FDB key containing an incomplete Versionstamp
+    ///   - value: Bytes value
+    ///   - commit: Whether to commit this transaction after action or not
+    ///
+    /// - Throws: Throws FDB.Error.missingIncompleteVersionstamp if a version stamp cannot be found
+    func set(versionstampedKey: AnyFDBKey, value: Bytes, commit: Bool = false) throws {
+        try self.set(versionstampedKey: versionstampedKey, value: value, commit: commit) as Void
     }
 
     /// Returns bytes value for given key (or `nil` if no key)
@@ -633,6 +676,21 @@ public extension AnyFDBTransaction {
     /// - returns: EventLoopFuture with future Transaction (`self`) value
     func set(key: AnyFDBKey, value: Bytes, commit: Bool = false) -> EventLoopFuture<AnyFDBTransaction> {
         return self.set(key: key, value: value, commit: commit)
+    }
+
+    /// Sets bytes to given versionstamped key in FDB cluster. If versionstampedKey does not contain
+    /// an incomplete version stamp, this method will throw an error. The actual version stamp used
+    /// may be retrieved by calling `getVersionstamp()` on the transaction.
+    ///
+    /// - parameters:
+    ///   - versionstampedKey: FDB key containing an incomplete Versionstamp
+    ///   - value: Bytes value
+    ///   - commit: Whether to commit this transaction after action or not
+    ///
+    /// - Throws: Throws FDB.Error.missingIncompleteVersionstamp if a version stamp cannot be found
+    /// - returns: EventLoopFuture with future Transaction (`self`) value
+    func set(versionstampedKey: AnyFDBKey, value: Bytes, commit: Bool = false) throws -> EventLoopFuture<AnyFDBTransaction> {
+        return try self.set(versionstampedKey: versionstampedKey, value: value, commit: commit)
     }
 
     /// Returns bytes value for given key (or `nil` if no key)

--- a/Sources/FDB/AnyFDBTransaction.swift
+++ b/Sources/FDB/AnyFDBTransaction.swift
@@ -291,6 +291,11 @@ public protocol AnyFDBTransaction {
     /// - returns: EventLoopFuture with future Int64 value
     func getReadVersion() -> EventLoopFuture<Int64>
 
+    /// Returns versionstamp which was used by any versionstamp operations in this transaction
+    ///
+    /// - returns: EventLoopFuture with future FDB.Versionstamp value
+    func getVersionstamp() -> EventLoopFuture<FDB.Versionstamp>
+
     /// Sync methods
 
     /// Commits current transaction
@@ -460,6 +465,13 @@ public protocol AnyFDBTransaction {
     ///
     /// - returns: Read version as Int64
     func getReadVersion() throws -> Int64
+
+    /// Returns versionstamp which was used by any versionstamp operations in this transaction
+    ///
+    /// This function will block current thread during execution
+    ///
+    /// - returns: Version stamp as FDB.Versionstamp
+    func getVersionstamp() throws -> FDB.Versionstamp
 }
 
 /// Sync methods

--- a/Sources/FDB/FDB/FDB+Errors.swift
+++ b/Sources/FDB/FDB/FDB+Errors.swift
@@ -101,6 +101,7 @@ public extension FDB {
         case unpackInvalidString
         
         case missingIncompleteVersionstamp
+        case invalidVersionstamp
 
         /// Returns and instance of FDB.Error from FDB error number
         public static func from(errno: FDB.Errno) -> Error {
@@ -178,6 +179,7 @@ public extension FDB {
             case 9704: result = .unpackInvalidBoundaries
             case 9705: result = .unpackInvalidString
             case 9800: result = .missingIncompleteVersionstamp
+            case 9801: result = .invalidVersionstamp
             default:
             FDB.logger.error("Unknown errno \(errno)")
             result = .unknownError
@@ -263,6 +265,7 @@ public extension FDB {
             case .unpackInvalidBoundaries:                result = 9704
             case .unpackInvalidString:                    result = 9705
             case .missingIncompleteVersionstamp:          result = 9800
+            case .invalidVersionstamp:                    result = 9801
             }
 
             return result

--- a/Sources/FDB/FDB/FDB+Errors.swift
+++ b/Sources/FDB/FDB/FDB+Errors.swift
@@ -99,6 +99,8 @@ public extension FDB {
         case unpackUnknownCode
         case unpackInvalidBoundaries
         case unpackInvalidString
+        
+        case missingIncompleteVersionstamp
 
         /// Returns and instance of FDB.Error from FDB error number
         public static func from(errno: FDB.Errno) -> Error {
@@ -175,6 +177,7 @@ public extension FDB {
             case 9703: result = .unpackUnknownCode
             case 9704: result = .unpackInvalidBoundaries
             case 9705: result = .unpackInvalidString
+            case 9800: result = .missingIncompleteVersionstamp
             default:
             FDB.logger.error("Unknown errno \(errno)")
             result = .unknownError
@@ -259,6 +262,7 @@ public extension FDB {
             case .unpackUnknownCode:                      result = 9703
             case .unpackInvalidBoundaries:                result = 9704
             case .unpackInvalidString:                    result = 9705
+            case .missingIncompleteVersionstamp:          result = 9800
             }
 
             return result

--- a/Sources/FDB/Future/Future+Bytes.swift
+++ b/Sources/FDB/Future/Future+Bytes.swift
@@ -1,11 +1,22 @@
 import CFDB
 
 extension FDB.Future {
-    /// Sets a closure to be executed when current future is resolved
+    /// Sets a closure to be executed when current future is resolved, returning bytes for the value
     func whenBytesReady(_ callback: @escaping (Bytes?) -> Void) throws {
         self.whenReady { future in
             do {
                 try callback(future.parseBytes())
+            } catch {
+                future.fail(with: error)
+            }
+        }
+    }
+    
+    /// Sets a closure to be executed when current future is resolved, returning bytes for the key
+    func whenKeyBytesReady(_ callback: @escaping (Bytes) -> Void) throws {
+        self.whenReady { future in
+            do {
+                try callback(future.parseKeyBytes())
             } catch {
                 future.fail(with: error)
             }
@@ -17,7 +28,7 @@ extension FDB.Future {
         return try self.waitAndCheck().parseBytes()
     }
 
-    /// Parses bytes result from current future
+    /// Parses value bytes result from current future
     ///
     /// Warning: this should be only called if future is in resolved state
     internal func parseBytes() throws -> Bytes? {
@@ -32,5 +43,15 @@ extension FDB.Future {
         }
 
         return readValue.getBytes(count: readValueLength)
+    }
+    
+    /// Parses key bytes result from current future
+    ///
+    /// Warning: this should be only called if future is in resolved state
+    func parseKeyBytes() throws -> Bytes {
+        var readKey: UnsafePointer<Byte>!
+        var readKeyLength: Int32 = 0
+        try fdb_future_get_key(self.pointer, &readKey, &readKeyLength).orThrow()
+        return readKey.getBytes(count: readKeyLength)
     }
 }

--- a/Sources/FDB/Transaction/Transaction+Internal+Async.swift
+++ b/Sources/FDB/Transaction/Transaction+Internal+Async.swift
@@ -135,4 +135,9 @@ internal extension FDB.Transaction {
     func getReadVersion() -> FDB.Future {
         return fdb_transaction_get_read_version(self.pointer).asFuture()
     }
+
+    /// Returns versionstamp which was used by any versionstamp operations in this transaction
+    func getVersionstamp() -> FDB.Future {
+        return fdb_transaction_get_versionstamp(self.pointer).asFuture()
+    }
 }

--- a/Sources/FDB/Transaction/Transaction+NIO.swift
+++ b/Sources/FDB/Transaction/Transaction+NIO.swift
@@ -378,15 +378,15 @@ public extension FDB.Transaction {
         }
         
         do {
-            try future.whenBytesReady { bytes in
-                guard let input = bytes, input.count == 10 else {
+            try future.whenKeyBytesReady { bytes in
+                guard bytes.count == 10 else {
                     self.log("[getVersionstamp] Bytes that do not represent a versionstamp were returned: \(String(describing: bytes))", level: .error)
                     promise.fail(FDB.Error.invalidVersionstamp)
                     return
                 }
                 
-                let transactionCommitVersion = try! UInt64(bigEndian: Bytes(input[0..<8]).cast())
-                let batchNumber = try! UInt16(bigEndian: Bytes(input[8..<10]).cast())
+                let transactionCommitVersion = try! UInt64(bigEndian: Bytes(bytes[0..<8]).cast())
+                let batchNumber = try! UInt16(bigEndian: Bytes(bytes[8..<10]).cast())
                 
                 let versionstamp = FDB.Versionstamp(transactionCommitVersion: transactionCommitVersion, batchNumber: batchNumber)
                 promise.succeed(versionstamp)

--- a/Sources/FDB/Transaction/Transaction+NIO.swift
+++ b/Sources/FDB/Transaction/Transaction+NIO.swift
@@ -60,6 +60,14 @@ public extension FDB.Transaction {
         return future
     }
 
+    func set(versionstampedKey: AnyFDBKey, value: Bytes, commit: Bool) throws -> EventLoopFuture<AnyFDBTransaction> {
+        var serializedKey = versionstampedKey.asFDBKey()
+        let offset = try FDB.Tuple.offsetOfFirstIncompleteVersionstamp(from: serializedKey)
+        serializedKey.append(contentsOf: getBytes(offset.littleEndian))
+        
+        return self.atomic(.setVersionstampedKey, key: serializedKey, value: value, commit: commit)
+    }
+
     func get(
         key: AnyFDBKey,
         snapshot: Bool,

--- a/Sources/FDB/Transaction/Transaction+Sync.swift
+++ b/Sources/FDB/Transaction/Transaction+Sync.swift
@@ -138,4 +138,8 @@ public extension FDB.Transaction {
     func getReadVersion() throws -> Int64 {
         return try self.getReadVersion().wait()
     }
+
+    func getVersionstamp() throws -> FDB.Versionstamp {
+        return try self.getVersionstamp().wait()
+    }
 }

--- a/Sources/FDB/Transaction/Transaction+Sync.swift
+++ b/Sources/FDB/Transaction/Transaction+Sync.swift
@@ -17,6 +17,14 @@ public extension FDB.Transaction {
             try self.commitSync()
         }
     }
+    
+    func set(versionstampedKey: AnyFDBKey, value: Bytes, commit: Bool) throws {
+        var serializedKey = versionstampedKey.asFDBKey()
+        let offset = try FDB.Tuple.offsetOfFirstIncompleteVersionstamp(from: serializedKey)
+        serializedKey.append(contentsOf: getBytes(offset.littleEndian))
+            
+        try self.atomic(.setVersionstampedKey, key: serializedKey, value: value, commit: commit) as Void
+    }
 
     func get(key: AnyFDBKey, snapshot: Bool, commit: Bool) throws -> Bytes? {
         let result: Bytes? = try self.get(key: key, snapshot: snapshot).wait()

--- a/Sources/FDB/Tuple.swift
+++ b/Sources/FDB/Tuple.swift
@@ -42,18 +42,20 @@ internal extension FDB.Tuple {
     static let NULL_ESCAPE_SEQUENCE: Bytes = [NULL, 0xFF]
 
     enum Prefix {
-        static let BYTE_STRING   = Byte(0x01)
-        static let UTF_STRING    = Byte(0x02)
-        static let NESTED_TUPLE  = Byte(0x05)
-        static let INT_ZERO_CODE = Byte(0x14)
-        static let POS_INT_END   = Byte(0x1D)
-        static let NEG_INT_START = Byte(0x0B)
-        static let FLOAT         = Byte(0x20)
-        static let DOUBLE        = Byte(0x21)
-        static let LONG_DOUBLE   = Byte(0x22)
-        static let BOOL_FALSE    = Byte(0x26)
-        static let BOOL_TRUE     = Byte(0x27)
-        static let UUID          = Byte(0x30)
+        static let BYTE_STRING          = Byte(0x01)
+        static let UTF_STRING           = Byte(0x02)
+        static let NESTED_TUPLE         = Byte(0x05)
+        static let INT_ZERO_CODE        = Byte(0x14)
+        static let POS_INT_END          = Byte(0x1D)
+        static let NEG_INT_START        = Byte(0x0B)
+        static let FLOAT                = Byte(0x20)
+        static let DOUBLE               = Byte(0x21)
+        static let LONG_DOUBLE          = Byte(0x22)
+        static let BOOL_FALSE           = Byte(0x26)
+        static let BOOL_TRUE            = Byte(0x27)
+        static let UUID                 = Byte(0x30)
+        static let VERSIONSTAMP_80BIT   = Byte(0x32)
+        static let VERSIONSTAMP_96BIT   = Byte(0x33)
     }
 }
 

--- a/Sources/FDB/Versionstamp.swift
+++ b/Sources/FDB/Versionstamp.swift
@@ -27,3 +27,23 @@ public extension FDB {
         }
     }
 }
+
+extension FDB.Versionstamp: FDBTuplePackable {
+    public func pack() -> Bytes {
+        var result = Bytes()
+        if userData == nil {
+            result.append(FDB.Tuple.Prefix.VERSIONSTAMP_80BIT)
+        } else {
+            result.append(FDB.Tuple.Prefix.VERSIONSTAMP_96BIT)
+        }
+        
+        result.append(contentsOf: getBytes(transactionCommitVersion.bigEndian))
+        result.append(contentsOf: getBytes(batchNumber.bigEndian))
+        
+        if let userData = userData {
+            result.append(contentsOf: getBytes(userData.bigEndian))
+        }
+        
+        return result
+    }
+}

--- a/Sources/FDB/Versionstamp.swift
+++ b/Sources/FDB/Versionstamp.swift
@@ -1,0 +1,29 @@
+public extension FDB {
+    
+    /// Versionstamp type, as implemented by the Python, Java, and Go bindings
+    struct Versionstamp: Equatable {
+        /// 8-bytes: A big-endian, unsigned version corresponding to the commit version of a transaction, immutable.
+        public let transactionCommitVersion: UInt64
+        /// 2-bytes: A big-endian, unsigned batch number ordering transactions that are committed at the same version, immutable.
+        public let batchNumber: UInt16
+        /// Optional 2-byes: Extra ordering information to order writes within a single transaction, thereby providing a global order for all versions.
+        public var userData: UInt16?
+        
+        /// Initializes a Versionstamp with the specified transaction commit version, batch number, and optional user data. If the user data is specified, a 96-bit versionstamp will be encoded, otherwise an 80-bit verstion stamp without the user data will be encoded.
+        /// - Parameters:
+        ///   - transactionCommitVersion: A big-endian, unsigned version corresponding to the commit version of a transaction.
+        ///   - batchNumber: A big-endian, unsigned batch number ordering transactions that are committed at the same version.
+        ///   - userData: Extra ordering information to order writes within a single transaction, thereby providing a global order for all versions.
+        public init(transactionCommitVersion: UInt64, batchNumber: UInt16, userData: UInt16? = nil) {
+            self.transactionCommitVersion = transactionCommitVersion
+            self.batchNumber = batchNumber
+            self.userData = userData
+        }
+        
+        /// Initializes a new incomplete Versionstamp suitable for passing to an atomic operation with the .setVersionstampedKey option. If the user data is specified, a 96-bit versionstamp will be encoded, otherwise an 80-bit verstion stamp without the user data will be encoded.
+        /// - Parameter userData: Extra ordering information to order writes within a single transaction, thereby providing a global order for all versions.
+        public init(userData: UInt16? = nil) {
+            self.init(transactionCommitVersion: 0, batchNumber: 0, userData: userData)
+        }
+    }
+}

--- a/Tests/FDBTests/FDBTests.swift
+++ b/Tests/FDBTests/FDBTests.swift
@@ -102,6 +102,18 @@ class FDBTests: XCTestCase {
         XCTAssertEqual(try fdb.decrement(key: key), 0)
     }
 
+    func testSetVersionstampedKey() throws {
+        let fdb = FDBTests.fdb!
+        let subspace = FDBTests.subspace.subspace("atomic_versionstamp")
+        let key = subspace[FDB.Versionstamp(userData: 42)]["mykey"]
+        
+        let value: String = "hello!"
+        
+        let tr = try self.begin().wait()
+        XCTAssertNoThrow(try tr.set(versionstampedKey: key, value: getBytes(value.utf8)) as Void)
+        XCTAssertNoThrow(try tr.commitSync())
+    }
+
     func testClear() throws {
         XCTAssertNoThrow(try FDBTests.fdb.clear(key: FDBTests.subspace["empty"]))
     }

--- a/Tests/FDBTests/TupleTests.swift
+++ b/Tests/FDBTests/TupleTests.swift
@@ -131,6 +131,8 @@ class TupleTests: XCTestCase {
             false,
             FDB.Null(),
             "foo\u{00}bar",
+            FDB.Versionstamp(transactionCommitVersion: 42, batchNumber: 42),
+            FDB.Versionstamp(userData: 73),
         ]
         let etalonTuple = FDB.Tuple(input)
         let packed = etalonTuple.pack()
@@ -238,6 +240,25 @@ class TupleTests: XCTestCase {
         XCTAssertEqual(uuid, unpacked.tuple[0] as! UUID)
         XCTAssertEqual(packed, unpacked.pack())
     }
+    
+    func testVersionstamp() throws {
+        let cases: [(FDB.Versionstamp, Bytes)] = [
+            (FDB.Versionstamp(transactionCommitVersion: 42, batchNumber: 196), [50, 00, 00, 00, 00, 00, 00, 00, 42, 00, 196]),
+            (FDB.Versionstamp(transactionCommitVersion: 42, batchNumber: 196, userData: nil), [50, 00, 00, 00, 00, 00, 00, 00, 42, 00, 196]),
+            (FDB.Versionstamp(transactionCommitVersion: 42, batchNumber: 196, userData: 0), [51, 00, 00, 00, 00, 00, 00, 00, 42, 00, 196, 00, 00]),
+            (FDB.Versionstamp(transactionCommitVersion: 42, batchNumber: 196, userData: 24), [51, 00, 00, 00, 00, 00, 00, 00, 42, 00, 196, 00, 24]),
+            (FDB.Versionstamp(), [50, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00]),
+            (FDB.Versionstamp(userData: nil), [50, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00]),
+            (FDB.Versionstamp(userData: 0), [51, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00]),
+            (FDB.Versionstamp(userData: 24), [51, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 24]),
+        ]
+
+        for (input, expectedBytes) in cases {
+            XCTAssertEqual(expectedBytes, input.pack())
+            let unpacked = try FDB.Tuple(from: expectedBytes)
+            XCTAssertEqual(input, unpacked.tuple[0] as! FDB.Versionstamp)
+        }
+    }
 
     static var allTests = [
         ("testPackUnicodeString", testPackUnicodeString),
@@ -252,5 +273,6 @@ class TupleTests: XCTestCase {
         ("testDouble", testDouble),
         ("testBool", testBool),
         ("testUUID", testUUID),
+        ("testVersionstamp", testVersionstamp),
     ]
 }


### PR DESCRIPTION
These changes add support for Versionstamps in a few specific ways:
1. Versionstamp is now a type that can be encoded in Tuples. There existed a concept of `complete` and `incomplete` versionstamps from the Python bindings that I borrowed here — specifically, an `incomplete` versionstamp is a placeholder that will be replaced when set on the database.
2. There is a new `set(versionstampedKey:value:commit)` suite of methods that will check the key for an `incomplete` versionstamp, get its offset, and append that offset to the end of the key's byte string. It will then delegate to the `atomic()` method with the right option to have the version stamp at the appended offset be replaced when written to the database.
3. Transactions have a new `getVersionstamp()` method that will fetch the version stamp used in a previous atomic write and return it as a future, so you can reference it, for instance.

There are a few issues:
- `testNetworkOptions()` seems to be failing, and I don't think it's anything I changed.
- The new `testSetVersionstampedKey()` will fail maybe 1/10 times - specifically, when calling `fdb_future_get_value()` when the `getVersionstamp()` future succeeds will return `0` for `readValueFound`. Not sure if I somehow managed to pass along the wrong future, found a bug in FDB, or wrote the wrong order of operations in the test. I must admit I'm still new to both FDB and to dealing with promises and futures, so I would readily assume I did something wrong, so if you manage to see anything that looks out of place, I would appreciate the feedback (Maybe it's my machine? I regularly run out of file descriptors, for instance, so I wouldn't be surprised if that's why it fails...). Good news is the error handling works 🙃 

Closes #58