### PR TITLE
Updated the meaning of an incomplete versionstamp to match existing bindings

### DIFF
--- a/Sources/FDB/Future/Future+Bytes.swift
+++ b/Sources/FDB/Future/Future+Bytes.swift
@@ -48,7 +48,7 @@ extension FDB.Future {
     /// Parses key bytes result from current future
     ///
     /// Warning: this should be only called if future is in resolved state
-    func parseKeyBytes() throws -> Bytes {
+    internal func parseKeyBytes() throws -> Bytes {
         var readKey: UnsafePointer<Byte>!
         var readKeyLength: Int32 = 0
         try fdb_future_get_key(self.pointer, &readKey, &readKeyLength).orThrow()

--- a/Sources/FDB/Versionstamp.swift
+++ b/Sources/FDB/Versionstamp.swift
@@ -23,11 +23,11 @@ public extension FDB {
         /// Initializes a new incomplete Versionstamp suitable for passing to an atomic operation with the .setVersionstampedKey option. If the user data is specified, a 96-bit versionstamp will be encoded, otherwise an 80-bit verstion stamp without the user data will be encoded.
         /// - Parameter userData: Extra ordering information to order writes within a single transaction, thereby providing a global order for all versions.
         public init(userData: UInt16? = nil) {
-            self.init(transactionCommitVersion: 0, batchNumber: 0, userData: userData)
+            self.init(transactionCommitVersion: 0xFFFFFFFFFFFFFFFF, batchNumber: 0xFFFF, userData: userData)
         }
         
         public var isComplete: Bool {
-            transactionCommitVersion != 0 || batchNumber != 0
+            transactionCommitVersion != 0xFFFFFFFFFFFFFFFF as UInt64 || batchNumber != 0xFFFF
         }
     }
 }

--- a/Tests/FDBTests/TupleTests.swift
+++ b/Tests/FDBTests/TupleTests.swift
@@ -247,10 +247,10 @@ class TupleTests: XCTestCase {
             (FDB.Versionstamp(transactionCommitVersion: 42, batchNumber: 196, userData: nil), [50, 00, 00, 00, 00, 00, 00, 00, 42, 00, 196]),
             (FDB.Versionstamp(transactionCommitVersion: 42, batchNumber: 196, userData: 0), [51, 00, 00, 00, 00, 00, 00, 00, 42, 00, 196, 00, 00]),
             (FDB.Versionstamp(transactionCommitVersion: 42, batchNumber: 196, userData: 24), [51, 00, 00, 00, 00, 00, 00, 00, 42, 00, 196, 00, 24]),
-            (FDB.Versionstamp(), [50, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00]),
-            (FDB.Versionstamp(userData: nil), [50, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00]),
-            (FDB.Versionstamp(userData: 0), [51, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00]),
-            (FDB.Versionstamp(userData: 24), [51, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 24]),
+            (FDB.Versionstamp(), [50, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
+            (FDB.Versionstamp(userData: nil), [50, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
+            (FDB.Versionstamp(userData: 0), [51, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 00, 00]),
+            (FDB.Versionstamp(userData: 24), [51, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 00, 24]),
         ]
 
         for (input, expectedBytes) in cases {


### PR DESCRIPTION
As is pointed out in https://forums.foundationdb.org/t/implementing-versionstamps-in-bindings/250, existing bindings use all `0xFF` rather than `0x00` for incomplete version stamps, likely because they will always come after any other version stamps lexicographically anyways.