### PR TITLE
Do not pass custom errors to `fdb_transaction_on_error` function

### DIFF
--- a/Sources/FDB/FDB/FDB+Errors.swift
+++ b/Sources/FDB/FDB/FDB+Errors.swift
@@ -279,6 +279,12 @@ public extension FDB {
             return result
         }
 
+        /// Indicates if current error is a native FoundationDB error
+        /// (i.e. errno is less than `8000`, after which custom FDBSwift errors start)
+        internal var isNative: Bool {
+            self.errno < 8000
+        }
+
         /// Returns human-readable description of current FDB error
         public func getDescription() -> String {
             if self.errno == 8000 {

--- a/Sources/FDB/Transaction/Transaction+NIO.swift
+++ b/Sources/FDB/Transaction/Transaction+NIO.swift
@@ -6,13 +6,14 @@ internal extension EventLoopFuture {
     func checkingRetryableError(for transaction: AnyFDBTransaction) -> EventLoopFuture {
         return self.flatMapError { error in
             guard
-                let FDBError = error as? FDB.Error,
-                let realTransaction = transaction as? FDB.Transaction
+                let fdbError = error as? FDB.Error,
+                let realTransaction = transaction as? FDB.Transaction,
+                fdbError.isNative
             else {
                 return self.eventLoop.makeFailedFuture(error)
             }
 
-            let onErrorFuture: FDB.Future = fdb_transaction_on_error(realTransaction.pointer, FDBError.errno).asFuture()
+            let onErrorFuture: FDB.Future = fdb_transaction_on_error(realTransaction.pointer, fdbError.errno).asFuture()
 
             let promise: EventLoopPromise<Value> = self.eventLoop.makePromise()
 


### PR DESCRIPTION
Currently FDBSwift have native FoundationDB errors combined with custom FDBSwift errors. Native errors have errno <= 4100, whereas custom errors start from 8000 (NB: this is generally a questionable decision, and I might rethink errors system in future versions, but not likely because I wouldn't like to break API stability). Generally it doesn't lead to any errors, but in rare cases custom errno is passed to `fdb_transaction_on_error` function (in `EventLoopFuture.checkingRetryableError` extension method which does recommended error handling), which results in undefined behavior and already resulted in some tests being unstable.

Tactical solution to this situation would be to fail current future in `EventLoopFuture.checkingRetryableError` before passing errno to `fdb_transaction_on_error` in case if errno belongs to custom errors range. Additionally, respective helper vars in `FDB.Error` should be created.