### PR TITLE
Network options enhancements

### DIFF
--- a/Tests/FDBTests/FDBTests.swift
+++ b/Tests/FDBTests/FDBTests.swift
@@ -408,6 +408,8 @@ class FDBTests: XCTestCase {
     func testNetworkOptions() throws {
         //XCTAssertThrowsError(try FDBTests.fdb.setOption(.TLSCertPath(path: "/tmp/invalidname")))
         //XCTAssertThrowsError(try FDBTests.fdb.setOption(.TLSCABytes(bytes: Bytes([1,2,3]))))
+        XCTAssertNoThrow(try FDBTests.fdb.setOption(.TLSVerifyPeers(string: "Check.Valid=0")))
+        XCTAssertNoThrow(try FDBTests.fdb.setOption(.TLSPassword(password: "some secret password")))
         XCTAssertNoThrow(try FDBTests.fdb.setOption(.buggifyDisable))
         XCTAssertNoThrow(try FDBTests.fdb.setOption(.buggifySectionActivatedProbability(probability: 0)))
     }


### PR DESCRIPTION
1. Since verify peers is always a string, but FDBSwift offers a `FDB.NetworkOption.TLSVerifyPeers(bytes:)` (for some reason), we should create a proxy static method `public static func TLSVerifyPeers(string: String)` and deprecate the `bytes` case.
2. Setting the TLSPassword option should not log actual password.