### PR TITLE
Make `FDBTuplePackable` methods more specific (and less general). More.

### DIFF
--- a/Sources/FDB/AnyFDBKey.swift
+++ b/Sources/FDB/AnyFDBKey.swift
@@ -10,25 +10,25 @@ public protocol AnyFDBKey: FDBTuplePackable {
 }
 
 public extension AnyFDBKey {
-    func pack() -> Bytes {
-        return self.asFDBKey().pack()
+    func getPackedFDBTupleValue() -> Bytes {
+        self.asFDBKey().getPackedFDBTupleValue()
     }
 }
 
 extension String: AnyFDBKey {
     public func asFDBKey() -> Bytes {
-        return Bytes(self.utf8)
+        Bytes(self.utf8)
     }
 }
 
 extension StaticString: AnyFDBKey {
     public func asFDBKey() -> Bytes {
-        return self.utf8Start.getBytes(count: Int32(self.utf8CodeUnitCount))
+        self.utf8Start.getBytes(count: Int32(self.utf8CodeUnitCount))
     }
 }
 
-extension Array: AnyFDBKey where Element == Byte {
+extension Bytes: AnyFDBKey {
     public func asFDBKey() -> Bytes {
-        return self
+        self
     }
 }

--- a/Sources/FDB/FDB/FDB+Errors.swift
+++ b/Sources/FDB/FDB/FDB+Errors.swift
@@ -299,7 +299,7 @@ public extension FDB {
 
         /// Returns FDB error description from error number
         public static func getErrorInfo(for errno: fdb_error_t) -> String {
-            return String(cString: fdb_get_error(errno))
+            String(cString: fdb_get_error(errno))
         }
     }
 }

--- a/Sources/FDB/Future/Future+Bytes.swift
+++ b/Sources/FDB/Future/Future+Bytes.swift
@@ -2,6 +2,7 @@ import CFDB
 
 extension FDB.Future {
     /// Blocks current thread until future is resolved
+    @inlinable
     internal func wait() throws -> Bytes? {
         try self.waitAndCheck().parseBytes()
     }
@@ -9,6 +10,7 @@ extension FDB.Future {
     /// Parses value bytes result from current future
     ///
     /// Warning: this should be only called if future is in resolved state
+    @inlinable
     internal func parseBytes() throws -> Bytes? {
         var readValueFound: Int32 = 0
         var readValue: UnsafePointer<Byte>!
@@ -26,6 +28,7 @@ extension FDB.Future {
     /// Parses key bytes result from current future
     ///
     /// Warning: this should be only called if future is in resolved state
+    @inlinable
     internal func parseKeyBytes() throws -> Bytes {
         var readKey: UnsafePointer<Byte>!
         var readKeyLength: Int32 = 0

--- a/Sources/FDB/Future/Future+Int64.swift
+++ b/Sources/FDB/Future/Future+Int64.swift
@@ -4,9 +4,12 @@ extension FDB.Future {
     /// Returns Future's version
     ///
     /// Should be called only when future is resolved
-    func getVersion() throws -> Int64 {
+    @inlinable
+    internal func getVersion() throws -> Int64 {
         var version: Int64 = 0
+
         try fdb_future_get_int64(self.pointer, &version).orThrow()
+
         return version
     }
 }

--- a/Sources/FDB/Future/Future+KeyValue.swift
+++ b/Sources/FDB/Future/Future+KeyValue.swift
@@ -4,6 +4,7 @@ extension FDB.Future {
     /// Parses key values result from current future
     ///
     /// Warning: this should be only called if future is in resolved state
+    @inlinable
     internal func parseKeyValues() throws -> FDB.KeyValuesResult {
         var outRawValues: UnsafePointer<FDBKeyValue>!
         var outCount: Int32 = 0

--- a/Sources/FDB/Helpers.swift
+++ b/Sources/FDB/Helpers.swift
@@ -7,12 +7,14 @@ public typealias Bytes = [Byte]
 internal extension String {
     @usableFromInline
     var bytes: Bytes {
-        return Bytes(self.utf8)
+        Bytes(self.utf8)
     }
 
     @usableFromInline
     var safe: String {
-        return self.unicodeScalars.lazy
+        self
+            .unicodeScalars
+            .lazy
             .map { scalar in
                 scalar == "\n"
                     ? "\n"
@@ -25,11 +27,11 @@ internal extension String {
 internal extension Bool {
     @usableFromInline
     var int: fdb_bool_t {
-        return self ? 1 : 0
+        self ? 1 : 0
     }
 }
 
-internal extension Array where Element == Byte {
+internal extension Bytes {
     @usableFromInline
     func cast<R>() throws -> R {
         guard MemoryLayout<R>.size == self.count else {
@@ -47,31 +49,31 @@ internal extension Array where Element == Byte {
 
     @usableFromInline
     var length: Int32 {
-        return numericCast(self.count)
+        numericCast(self.count)
     }
 
     @usableFromInline
     var string: String {
-        return String(bytes: self, encoding: .ascii)!
+        String(bytes: self, encoding: .ascii)!
     }
 }
 
 /// Returns little-endian binary representation of arbitrary value
 @usableFromInline
 internal func getBytes<Input>(_ input: Input) -> Bytes {
-    return withUnsafeBytes(of: input) { Bytes($0) }
+    withUnsafeBytes(of: input) { Bytes($0) }
 }
 
 /// Returns big-endian IEEE binary representation of a floating point number
 @usableFromInline
 internal func getBytes(_ input: Float32) -> Bytes {
-    return getBytes(input.bitPattern.bigEndian)
+    getBytes(input.bitPattern.bigEndian)
 }
 
 /// Returns big-endian IEEE binary representation of a double number
 @usableFromInline
 internal func getBytes(_ input: Double) -> Bytes {
-    return getBytes(input.bitPattern.bigEndian)
+    getBytes(input.bitPattern.bigEndian)
 }
 
 // taken from Swift-NIO
@@ -106,7 +108,7 @@ internal extension UnsafeRawPointer {
     // Boy this is unsafe :D
     @usableFromInline
     func getBytes(count: Int32) -> Bytes {
-        return self.assumingMemoryBound(to: Byte.self).getBytes(count: count)
+        self.assumingMemoryBound(to: Byte.self).getBytes(count: count)
     }
 }
 

--- a/Sources/FDB/KeyValues.swift
+++ b/Sources/FDB/KeyValues.swift
@@ -17,12 +17,12 @@ public extension FDB {
 
 extension FDB.KeyValue: Equatable {
     public static func == (lhs: FDB.KeyValue, rhs: FDB.KeyValue) -> Bool {
-        return lhs.key == rhs.key && lhs.value == rhs.value
+        lhs.key == rhs.key && lhs.value == rhs.value
     }
 }
 
 extension FDB.KeyValuesResult: Equatable {
     public static func == (lhs: FDB.KeyValuesResult, rhs: FDB.KeyValuesResult) -> Bool {
-        return lhs.records == rhs.records && lhs.hasMore == rhs.hasMore
+        lhs.records == rhs.records && lhs.hasMore == rhs.hasMore
     }
 }

--- a/Sources/FDB/Subspace.swift
+++ b/Sources/FDB/Subspace.swift
@@ -10,7 +10,7 @@ public extension FDB {
         public let itemsCount: Int
 
         public var range: FDB.RangeKey {
-            return (
+            (
                 begin: self.prefix + [0],
                 end: self.prefix + [255]
             )
@@ -26,25 +26,25 @@ public extension FDB {
         }
 
         public init(_ tuple: Tuple, items: Int = 1) {
-            self.init(tuple.pack(), items: items)
+            self.init(tuple.getPackedFDBTupleValue(), items: items)
         }
 
         func subspace(_ input: [FDBTuplePackable]) -> Subspace {
-            return Subspace(self.prefix + Tuple(input).pack(), items: self.itemsCount + input.count)
+            Subspace(self.prefix + Tuple(input).getPackedFDBTupleValue(), items: self.itemsCount + input.count)
         }
 
         func subspace(_ input: FDBTuplePackable...) -> Subspace {
-            return self.subspace(input)
+            self.subspace(input)
         }
 
         public subscript(index: FDBTuplePackable...) -> Subspace {
-            return self.subspace(index)
+            self.subspace(index)
         }
     }
 }
 
 extension FDB.Subspace: AnyFDBKey {
     public func asFDBKey() -> Bytes {
-        return self.prefix
+        self.prefix
     }
 }

--- a/Sources/FDB/Transaction/Transaction+Internal+Async.swift
+++ b/Sources/FDB/Transaction/Transaction+Internal+Async.swift
@@ -4,6 +4,7 @@ internal extension FDB.Transaction {
     /// Commits current transaction
     func commit() -> FDB.Future {
         self.log("Committing transaction")
+
         return fdb_transaction_commit(self.pointer).asFuture(ref: self)
     }
 

--- a/Sources/FDB/Tuple/Tuple+Array.swift
+++ b/Sources/FDB/Tuple/Tuple+Array.swift
@@ -1,6 +1,8 @@
 /// Packs input bytes as BYTE STRING tuple value with null bytes escaping preprocessing
+@usableFromInline
 internal func packBytes(_ bytes: Bytes) -> Bytes {
     var result = Bytes()
+
     result.append(FDB.Tuple.Prefix.BYTE_STRING)
     bytes.forEach {
         if $0 == FDB.Tuple.NULL {
@@ -10,11 +12,12 @@ internal func packBytes(_ bytes: Bytes) -> Bytes {
         }
     }
     result.append(FDB.Tuple.NULL)
+
     return result
 }
 
-extension Array: FDBTuplePackable where Element == Byte {
-    public func pack() -> Bytes {
-        return packBytes(self)
+extension Bytes: FDBTuplePackable {
+    public func getPackedFDBTupleValue() -> Bytes {
+        packBytes(self)
     }
 }

--- a/Sources/FDB/Tuple/Tuple+Bool.swift
+++ b/Sources/FDB/Tuple/Tuple+Bool.swift
@@ -1,6 +1,6 @@
 extension Bool: FDBTuplePackable {
-    public func pack() -> Bytes {
-        return self
+    public func getPackedFDBTupleValue() -> Bytes {
+        self
             ? [FDB.Tuple.Prefix.BOOL_TRUE]
             : [FDB.Tuple.Prefix.BOOL_FALSE]
     }

--- a/Sources/FDB/Tuple/Tuple+FloatingPoint.swift
+++ b/Sources/FDB/Tuple/Tuple+FloatingPoint.swift
@@ -13,20 +13,24 @@ internal func transformFloatingPoint(bytes: inout Bytes, start: Int, encode: Boo
     }
 }
 
+@inlinable
+internal func getGenericFloatFDBTupleValue(input: Bytes, prefix: Byte) -> Bytes {
+    var result = Bytes([prefix])
+
+    result.append(contentsOf: input)
+    transformFloatingPoint(bytes: &result, start: 1, encode: true)
+
+    return result
+}
+
 extension Float32: FDBTuplePackable {
-    public func pack() -> Bytes {
-        var result = Bytes([FDB.Tuple.Prefix.FLOAT])
-        result.append(contentsOf: getBytes(self))
-        transformFloatingPoint(bytes: &result, start: 1, encode: true)
-        return result
+    public func getPackedFDBTupleValue() -> Bytes {
+        getGenericFloatFDBTupleValue(input: getBytes(self), prefix: FDB.Tuple.Prefix.FLOAT)
     }
 }
 
 extension Double: FDBTuplePackable {
-    public func pack() -> Bytes {
-        var result = Bytes([FDB.Tuple.Prefix.DOUBLE])
-        result.append(contentsOf: getBytes(self))
-        transformFloatingPoint(bytes: &result, start: 1, encode: true)
-        return result
+    public func getPackedFDBTupleValue() -> Bytes {
+        getGenericFloatFDBTupleValue(input: getBytes(self), prefix: FDB.Tuple.Prefix.DOUBLE)
     }
 }

--- a/Sources/FDB/Tuple/Tuple+Int.swift
+++ b/Sources/FDB/Tuple/Tuple+Int.swift
@@ -2,29 +2,34 @@ extension Collection {
     internal subscript(from i: Int) -> SubSequence {
         let _from = self.index(self.endIndex, offsetBy: i)
         let _to = self.endIndex
+
         return self[_from ..< _to]
     }
 }
 
 internal func bisect(list: [Int], item: Int) -> Int {
     var count = 0
+
     for i in list {
         if i >= item {
             break
         }
         count += 1
     }
+
     return count
 }
 
 internal let sizeLimits = Array<Int>(0 ... 7).map { (1 << ($0 * 8)) - 1 }
 
 extension Int: FDBTuplePackable {
-    public func pack() -> Bytes {
+    public func getPackedFDBTupleValue() -> Bytes {
         if self == 0 {
             return [FDB.Tuple.Prefix.INT_ZERO_CODE]
         }
+
         var result = Bytes()
+
         if self > 0 {
             let n = bisect(list: sizeLimits, item: self)
             result.append(FDB.Tuple.Prefix.INT_ZERO_CODE + UInt8(n))
@@ -36,6 +41,7 @@ extension Int: FDBTuplePackable {
             let bytes = getBytes((maxv + self).bigEndian)
             result.append(contentsOf: bytes[from: -n])
         }
+
         return result
     }
 }

--- a/Sources/FDB/Tuple/Tuple+String.swift
+++ b/Sources/FDB/Tuple/Tuple+String.swift
@@ -1,9 +1,9 @@
 extension String: FDBTuplePackable {
-    public func pack() -> Bytes {
-        let bytes = Bytes(self.utf8)
+    public func getPackedFDBTupleValue() -> Bytes {
         var result = Bytes()
+
         result.append(FDB.Tuple.Prefix.UTF_STRING)
-        bytes.forEach {
+        Bytes(self.utf8).forEach {
             if $0 == FDB.Tuple.NULL {
                 result.append(contentsOf: FDB.Tuple.NULL_ESCAPE_SEQUENCE)
             } else {
@@ -11,6 +11,7 @@ extension String: FDBTuplePackable {
             }
         }
         result.append(FDB.Tuple.NULL)
+
         return result
     }
 }

--- a/Sources/FDB/Tuple/Tuple+UUID.swift
+++ b/Sources/FDB/Tuple/Tuple+UUID.swift
@@ -1,9 +1,11 @@
 import Foundation
 
 extension UUID: FDBTuplePackable {
-    public func pack() -> Bytes {
+    public func getPackedFDBTupleValue() -> Bytes {
         var result: Bytes = [FDB.Tuple.Prefix.UUID]
+
         result.append(contentsOf: getBytes(self.uuid))
+
         return result
     }
 }

--- a/Sources/FDB/Tuple/Tuple+Unpack.swift
+++ b/Sources/FDB/Tuple/Tuple+Unpack.swift
@@ -1,7 +1,8 @@
 import Foundation
 import LGNLog
 
-fileprivate func findTerminator(input: Bytes, pos: Int) -> Int {
+@inlinable
+internal func findTerminator(input: Bytes, pos: Int) -> Int {
     let length = input.count
     var _pos = pos
     while true {

--- a/Sources/FDB/Versionstamp.swift
+++ b/Sources/FDB/Versionstamp.swift
@@ -6,8 +6,10 @@ public extension FDB {
     struct Versionstamp: Equatable {
         /// 8-bytes: A big-endian, unsigned version corresponding to the commit version of a transaction, immutable.
         public let transactionCommitVersion: UInt64
+
         /// 2-bytes: A big-endian, unsigned batch number ordering transactions that are committed at the same version, immutable.
         public let batchNumber: UInt16
+
         /// Optional 2-byes: Extra ordering information to order writes within a single transaction, thereby providing a global order for all versions.
         public var userData: UInt16?
         
@@ -35,8 +37,9 @@ public extension FDB {
 }
 
 extension FDB.Versionstamp: FDBTuplePackable {
-    public func pack() -> Bytes {
+    public func getPackedFDBTupleValue() -> Bytes {
         var result = Bytes()
+
         if userData == nil {
             result.append(FDB.Tuple.Prefix.VERSIONSTAMP_80BIT)
         } else {

--- a/Tests/FDBTests/TupleTests.swift
+++ b/Tests/FDBTests/TupleTests.swift
@@ -25,7 +25,7 @@ class TupleTests: XCTestCase {
         expected.append(0xFF)
         expected.append(contentsOf: "bar".bytes)
         expected.append(0x00)
-        XCTAssertEqual("F\u{00d4}O\u{0000}bar".pack(), expected)
+        XCTAssertEqual("F\u{00d4}O\u{0000}bar".getPackedFDBTupleValue(), expected)
     }
 
     func testPackBinaryString() {
@@ -36,7 +36,7 @@ class TupleTests: XCTestCase {
         expected.append(0xFF)
         expected.append(contentsOf: "bar".bytes)
         expected.append(0x00)
-        XCTAssertEqual("foo\u{00}bar".bytes.pack(), expected)
+        XCTAssertEqual("foo\u{00}bar".bytes.getPackedFDBTupleValue(), expected)
     }
 
     func testPackNestedTuple() {
@@ -60,7 +60,7 @@ class TupleTests: XCTestCase {
         expected.append(0x05)
         expected.append(0x00)
         expected.append(0x00)
-        XCTAssertEqual(tuple.pack(), expected)
+        XCTAssertEqual(tuple.getPackedFDBTupleValue(), expected)
     }
 
     func testPackInts() {
@@ -111,7 +111,7 @@ class TupleTests: XCTestCase {
             // 100000000000000000322: [29, 9, 5, 107, 199, 94, 45, 99, 16, 1, 66],
         ]
         for (input, expected) in cases {
-            XCTAssertEqual(input.pack(), expected)
+            XCTAssertEqual(input.getPackedFDBTupleValue(), expected)
         }
     }
 
@@ -120,7 +120,7 @@ class TupleTests: XCTestCase {
         expected.append(contentsOf: [0x13, 0xFE, 0x14, 0x15, 0x05, 0x05, 0x02])
         expected.append(contentsOf: "foo".bytes)
         expected.append(contentsOf: [0x00, 0x00, 0x00])
-        XCTAssertEqual(FDB.Tuple(-1, 0, 5, FDB.Tuple("foo"), FDB.Null()).pack(), expected)
+        XCTAssertEqual(FDB.Tuple(-1, 0, 5, FDB.Tuple("foo"), FDB.Null()).getPackedFDBTupleValue(), expected)
     }
 
     func testUnpack() throws {
@@ -143,15 +143,15 @@ class TupleTests: XCTestCase {
             FDB.Versionstamp(userData: 73),
         ]
         let etalonTuple = FDB.Tuple(input)
-        let packed = etalonTuple.pack()
-        let repacked = try FDB.Tuple(from: packed).pack()
+        let packed = etalonTuple.getPackedFDBTupleValue()
+        let repacked = try FDB.Tuple(from: packed).getPackedFDBTupleValue()
         XCTAssertEqual(packed, repacked)
     }
 
     // Fixes https://github.com/kirilltitov/FDBSwift/issues/10
     func testNullEscapes() throws {
-        let packed = Bytes([0, 0, 0,]).pack()
-        let repacked = try FDB.Tuple(from: packed).pack()
+        let packed = Bytes([0, 0, 0,]).getPackedFDBTupleValue()
+        let repacked = try FDB.Tuple(from: packed).getPackedFDBTupleValue()
         XCTAssertEqual(packed, repacked)
     }
 
@@ -168,10 +168,10 @@ class TupleTests: XCTestCase {
     func testFloat() throws {
         for _ in 0...1000 {
             let random = Float32.random(in: -1000...1000)
-            let packed = random.pack()
+            let packed = random.getPackedFDBTupleValue()
             let unpacked = try FDB.Tuple(from: packed)
             XCTAssertEqual(random, unpacked.tuple[0] as! Float)
-            let repacked = unpacked.pack()
+            let repacked = unpacked.getPackedFDBTupleValue()
             XCTAssertEqual(packed, repacked)
         }
 
@@ -191,17 +191,17 @@ class TupleTests: XCTestCase {
         ]
 
         for (inputFloat, expectedBytes) in cases {
-            XCTAssertEqual(expectedBytes, inputFloat.pack())
+            XCTAssertEqual(expectedBytes, inputFloat.getPackedFDBTupleValue())
         }
     }
 
     func testDouble() throws {
         for _ in 0...1000 {
             let random = Double.random(in: -1000...1000)
-            let packed = random.pack()
+            let packed = random.getPackedFDBTupleValue()
             let unpacked = try FDB.Tuple(from: packed)
             XCTAssertEqual(random, unpacked.tuple[0] as! Double)
-            let repacked = unpacked.pack()
+            let repacked = unpacked.getPackedFDBTupleValue()
             XCTAssertEqual(packed, repacked)
         }
 
@@ -222,19 +222,19 @@ class TupleTests: XCTestCase {
         ]
 
         for (inputFloat, expectedBytes) in cases {
-            XCTAssertEqual(expectedBytes, inputFloat.pack())
+            XCTAssertEqual(expectedBytes, inputFloat.getPackedFDBTupleValue())
         }
     }
 
     func testBool() throws {
-        XCTAssertEqual([0x26], false.pack())
-        XCTAssertEqual([0x27], true.pack())
+        XCTAssertEqual([0x26], false.getPackedFDBTupleValue())
+        XCTAssertEqual([0x27], true.getPackedFDBTupleValue())
 
         for bool in [true, false] {
-            let packed = bool.pack()
+            let packed = bool.getPackedFDBTupleValue()
             let unpacked = try FDB.Tuple(from: packed)
             XCTAssertEqual(bool, unpacked.tuple[0] as! Bool)
-            let repacked = unpacked.pack()
+            let repacked = unpacked.getPackedFDBTupleValue()
             XCTAssertEqual(packed, repacked)
         }
     }
@@ -242,11 +242,11 @@ class TupleTests: XCTestCase {
     func testUUID() throws {
         let etalon: uuid_t = (136,167,235,150,108,115,69,118,164,45,145,99,222,237,56,59)
         let uuid = UUID(uuid: etalon)
-        let packed = uuid.pack()
+        let packed = uuid.getPackedFDBTupleValue()
         XCTAssertEqual([0x30] + getBytes(etalon), packed)
         let unpacked = try FDB.Tuple(from: packed)
         XCTAssertEqual(uuid, unpacked.tuple[0] as! UUID)
-        XCTAssertEqual(packed, unpacked.pack())
+        XCTAssertEqual(packed, unpacked.getPackedFDBTupleValue())
     }
     
     func testVersionstamp() throws {
@@ -262,7 +262,7 @@ class TupleTests: XCTestCase {
         ]
 
         for (input, expectedBytes) in cases {
-            XCTAssertEqual(expectedBytes, input.pack())
+            XCTAssertEqual(expectedBytes, input.getPackedFDBTupleValue())
             let unpacked = try FDB.Tuple(from: expectedBytes)
             XCTAssertEqual(input, unpacked.tuple[0] as! FDB.Versionstamp)
         }
@@ -270,16 +270,16 @@ class TupleTests: XCTestCase {
     
     func testIncompleteVersionstampDetection() throws {
         let cases: [(Bytes, UInt32)] = [
-            (FDB.Tuple(FDB.Versionstamp()).pack(), 1),
-            (FDB.Tuple(FDB.Versionstamp(userData: 0)).pack(), 1),
-            (FDB.Tuple("foo", FDB.Versionstamp()).pack(), 6),
-            (FDB.Tuple("foo", FDB.Versionstamp(userData: 0)).pack(), 6),
-            (FDB.Tuple("foo", FDB.Versionstamp(), FDB.Versionstamp()).pack(), 6),
-            (FDB.Tuple("foo", FDB.Versionstamp(transactionCommitVersion: 12, batchNumber: 0), FDB.Versionstamp(), FDB.Versionstamp()).pack(), 17),
-            (FDB.Tuple("foo", FDB.Versionstamp(transactionCommitVersion: 0, batchNumber: 12), FDB.Versionstamp(), FDB.Versionstamp()).pack(), 17),
-            (FDB.Tuple("foo", FDB.Tuple(FDB.Versionstamp())).pack(), 7),
-            (FDB.Tuple("foo", FDB.Tuple(FDB.Versionstamp()), FDB.Versionstamp()).pack(), 7),
-            (FDB.Tuple("foo", FDB.Tuple("bar", FDB.Versionstamp()), FDB.Versionstamp()).pack(), 12),
+            (FDB.Tuple(FDB.Versionstamp()).getPackedFDBTupleValue(), 1),
+            (FDB.Tuple(FDB.Versionstamp(userData: 0)).getPackedFDBTupleValue(), 1),
+            (FDB.Tuple("foo", FDB.Versionstamp()).getPackedFDBTupleValue(), 6),
+            (FDB.Tuple("foo", FDB.Versionstamp(userData: 0)).getPackedFDBTupleValue(), 6),
+            (FDB.Tuple("foo", FDB.Versionstamp(), FDB.Versionstamp()).getPackedFDBTupleValue(), 6),
+            (FDB.Tuple("foo", FDB.Versionstamp(transactionCommitVersion: 12, batchNumber: 0), FDB.Versionstamp(), FDB.Versionstamp()).getPackedFDBTupleValue(), 17),
+            (FDB.Tuple("foo", FDB.Versionstamp(transactionCommitVersion: 0, batchNumber: 12), FDB.Versionstamp(), FDB.Versionstamp()).getPackedFDBTupleValue(), 17),
+            (FDB.Tuple("foo", FDB.Tuple(FDB.Versionstamp())).getPackedFDBTupleValue(), 7),
+            (FDB.Tuple("foo", FDB.Tuple(FDB.Versionstamp()), FDB.Versionstamp()).getPackedFDBTupleValue(), 7),
+            (FDB.Tuple("foo", FDB.Tuple("bar", FDB.Versionstamp()), FDB.Versionstamp()).getPackedFDBTupleValue(), 12),
         ]
 
         for (packedInput, offset) in cases {
@@ -288,14 +288,14 @@ class TupleTests: XCTestCase {
         }
         
         let invalidCases: [Bytes] = [
-            FDB.Tuple().pack(),
-            FDB.Tuple(42, "foo").pack(),
-            FDB.Tuple(FDB.Versionstamp(transactionCommitVersion: 42, batchNumber: 0)).pack(),
-            FDB.Tuple(FDB.Versionstamp(transactionCommitVersion: 0, batchNumber: 12)).pack(),
-            FDB.Tuple(FDB.Versionstamp(transactionCommitVersion: 42, batchNumber: 12, userData: 0)).pack(),
-            FDB.Tuple(42, "foo", FDB.Versionstamp(transactionCommitVersion: 42, batchNumber: 0)).pack(),
-            FDB.Tuple(42, "foo", FDB.Versionstamp(transactionCommitVersion: 0, batchNumber: 12)).pack(),
-            FDB.Tuple(42, "foo", FDB.Versionstamp(transactionCommitVersion: 42, batchNumber: 12, userData: 0)).pack(),
+            FDB.Tuple().getPackedFDBTupleValue(),
+            FDB.Tuple(42, "foo").getPackedFDBTupleValue(),
+            FDB.Tuple(FDB.Versionstamp(transactionCommitVersion: 42, batchNumber: 0)).getPackedFDBTupleValue(),
+            FDB.Tuple(FDB.Versionstamp(transactionCommitVersion: 0, batchNumber: 12)).getPackedFDBTupleValue(),
+            FDB.Tuple(FDB.Versionstamp(transactionCommitVersion: 42, batchNumber: 12, userData: 0)).getPackedFDBTupleValue(),
+            FDB.Tuple(42, "foo", FDB.Versionstamp(transactionCommitVersion: 42, batchNumber: 0)).getPackedFDBTupleValue(),
+            FDB.Tuple(42, "foo", FDB.Versionstamp(transactionCommitVersion: 0, batchNumber: 12)).getPackedFDBTupleValue(),
+            FDB.Tuple(42, "foo", FDB.Versionstamp(transactionCommitVersion: 42, batchNumber: 12, userData: 0)).getPackedFDBTupleValue(),
         ]
 
         for packedInput in invalidCases {


### PR DESCRIPTION
Currently this protocol requires a very generic method name `get` (and `_get`) which is not good for readability, clarity and generally not swifty. Those methods should be renamed to be more FDB-specific.

Additional formatting cleanup should be done. And maybe the whole thing will be a few CPU ticks faster because of more inlinable methods.

Closes #55.